### PR TITLE
feat: [ENG-601] implement functionality required for migration

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,7 @@
+export const capitalize = (name: string) => {
+  const [head, ...tail] = name;
+  if (head === undefined) {
+    return name;
+  }
+  return `${head.toUpperCase()}${tail.join("")}`;
+};


### PR DESCRIPTION
- feat: initial support for Type.Union vs Type.Enum
- feat: add support for arrays of enum types
- feat: add support for "unknown" object types with no properties
- fix: improve support for nullable literal types (eg: `type: ['string', 'null']`)
- chore: begin work on disambiguation of nested Enum/Union types
- refactor: break out some utils into separate file
- chore: update errors to include property name where error was thrown