### PR TITLE
Union type preference by pdfowler (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,18 +75,18 @@ Creating TypeBox code from JSON schemas.
 // Which becomes..
 //
 
-export enum FavoriteAnimalEnum {
-  DOG = "dog",
-  CAT = "cat",
-  SLOTH = "sloth",
-}
-
 export type Person = Static<typeof Person>;
 export const Person = Type.Object({
   name: Type.String({ minLength: 20 }),
   age: Type.Number({ minimum: 18, maximum: 90 }),
   hobbies: Type.Optional(Type.Array(Type.String(), { minItems: 1 })),
-  favoriteAnimal: Type.Optional(Type.Enum(FavoriteAnimalEnum)),
+  favoriteAnimal: Type.Optional(
+    Type.Union([
+      Type.Literal("dog"),
+      Type.Literal("cat"),
+      Type.Literal("sloth"),
+    ])
+  ),
 });
 
 //
@@ -136,19 +136,19 @@ export const Person = Type.Object({
 // Will result in this:
 //
 
-export enum StatusEnum {
-  UNKNOWN = "unknown",
-  ACCEPTED = "accepted",
-  DENIED = "denied",
-}
-
 export type Contract = Static<typeof Contract>;
 export const Contract = Type.Object({
   person: Type.Object({
     name: Type.String({ maxLength: 100 }),
     age: Type.Number({ minimum: 18 }),
   }),
-  status: Type.Optional(Type.Enum(StatusEnum)),
+  status: Type.Optional(
+      Type.Union([
+        Type.Literal("unknown"),
+        Type.Literal("accepted"),
+        Type.Literal("denied"),
+      ])
+   ),
 });
 
 //
@@ -195,9 +195,11 @@ whats already implemented and what is missing.
 - [x] Type.Array() via "array" instance type
 - [x] Type.Object() via "object" instance type
 - [x] Type.Literal() via "const" property
-- [x] Type.Union() via "anyOf" property
+- [x] Type.Union() via "anyOf" or "enum" property
+  - schema2typebox generates union types instead of enums. If you have a problem
+    with this behaviour and valid arguments for using enums please create an
+    issue and it may be considered again.
 - [x] Type.Intersect() via "allOf" property
-- [x] Type.Enum() via "enum" property
 - [x] OneOf() via "oneOf" property
   - This adds oneOf to the typebox type registry as (Kind: 'ExtendedOneOf') in
     order to be able to align to oneOf json schema semantics and still be able
@@ -210,6 +212,15 @@ whats already implemented and what is missing.
       Defaulting to "T" if title is not defined.
 - [ ] (low prio) Type.Tuple() via "array" instance type with minimalItems,
       maximalItems and additionalItems false
+
+#### Open Tasks
+
+See [here](https://github.com/xddq/schema2typebox/pull/23) and followup PRs.
+
+- [ ] Type.Array() with "array<enum>" instance type
+- [ ] Nullable Literal types, eg: `type: ['string', 'null']`
+- [ ] "Unknown" object types
+- [ ] Disambiguation of overlapping property names in nested schemas
 
 ## DEV/CONTRIBUTOR NOTES
 

--- a/examples/basic/generated-typebox.ts
+++ b/examples/basic/generated-typebox.ts
@@ -8,16 +8,16 @@
 
 import { Static, Type } from "@sinclair/typebox";
 
-export enum FavoriteAnimalEnum {
-  DOG = "dog",
-  CAT = "cat",
-  SLOTH = "sloth",
-}
-
 export type Person = Static<typeof Person>;
 export const Person = Type.Object({
   name: Type.String({ minLength: 20 }),
   age: Type.Number({ minimum: 18, maximum: 90 }),
   hobbies: Type.Optional(Type.Array(Type.String(), { minItems: 1 })),
-  favoriteAnimal: Type.Optional(Type.Enum(FavoriteAnimalEnum)),
+  favoriteAnimal: Type.Optional(
+    Type.Union([
+      Type.Literal("dog"),
+      Type.Literal("cat"),
+      Type.Literal("sloth"),
+    ])
+  ),
 });

--- a/examples/programmatic-usage/generated-typebox.ts
+++ b/examples/programmatic-usage/generated-typebox.ts
@@ -8,16 +8,16 @@
 
 import { Static, Type } from "@sinclair/typebox";
 
-export enum FavoriteAnimalEnum {
-  DOG = "dog",
-  CAT = "cat",
-  SLOTH = "sloth",
-}
-
 export type Person = Static<typeof Person>;
 export const Person = Type.Object({
   name: Type.String({ minLength: 20 }),
   age: Type.Number({ minimum: 18, maximum: 90 }),
   hobbies: Type.Optional(Type.Array(Type.String(), { minItems: 1 })),
-  favoriteAnimal: Type.Optional(Type.Enum(FavoriteAnimalEnum)),
+  favoriteAnimal: Type.Optional(
+    Type.Union([
+      Type.Literal("dog"),
+      Type.Literal("cat"),
+      Type.Literal("sloth"),
+    ])
+  ),
 });

--- a/examples/ref-to-relative-files/generated-typebox.ts
+++ b/examples/ref-to-relative-files/generated-typebox.ts
@@ -8,17 +8,17 @@
 
 import { Static, Type } from "@sinclair/typebox";
 
-export enum StatusEnum {
-  UNKNOWN = "unknown",
-  ACCEPTED = "accepted",
-  DENIED = "denied",
-}
-
 export type Contract = Static<typeof Contract>;
 export const Contract = Type.Object({
   person: Type.Object({
     name: Type.String({ maxLength: 100 }),
     age: Type.Number({ minimum: 18 }),
   }),
-  status: Type.Optional(Type.Enum(StatusEnum)),
+  status: Type.Optional(
+    Type.Union([
+      Type.Literal("unknown"),
+      Type.Literal("accepted"),
+      Type.Literal("denied"),
+    ])
+  ),
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "schema2typebox",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "main": "dist/src/index.js",
   "description": "Creates typebox code from JSON schemas",
   "source": "dist/src/index.js",
@@ -48,7 +48,7 @@
   ],
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "9.0.9",
-    "@sinclair/typebox": "0.29.0",
+    "@sinclair/typebox": "0.30.2",
     "cosmiconfig": "8.1.3",
     "fp-ts": "2.16.0",
     "minimist": "1.2.8",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,16 @@
+/**
+ * @description Capitalizes the first letter of a string
+ * @throws Error if name is empty string
+ * @returns The capitalized string
+ */
+export const capitalize = (name: string) => {
+  const [head, ...tail] = name;
+  // just name.length is needed but adding head === undefined check to make
+  // typescript happy
+  if (name.length === 0 || head === undefined) {
+    throw new Error(
+      "Unexpected input when capitalizing. Did not expect empty string."
+    );
+  }
+  return `${head.toUpperCase()}${tail.join("")}`;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -345,10 +345,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sinclair/typebox@npm:0.29.0":
-  version: 0.29.0
-  resolution: "@sinclair/typebox@npm:0.29.0"
-  checksum: eefe2217c7e18b4f5c0ba4a345f371fdcd1092faf1905a7cf9c758aebbae73500bec16c68beab39a735cba1f0a758963997a4780adefb7ce67934b87f80ef747
+"@sinclair/typebox@npm:0.30.2":
+  version: 0.30.2
+  resolution: "@sinclair/typebox@npm:0.30.2"
+  checksum: ddb5368b6a11b953edd511d62e4b575c46bafabcc7de815f64be7f34dbfc63649ef1651c0687af952ac6a9b3aba03d2f91ec0dd9ec7d8a1ca24e35b4d6e60ac9
   languageName: node
   linkType: hard
 
@@ -2505,7 +2505,7 @@ __metadata:
   resolution: "schema2typebox@workspace:."
   dependencies:
     "@apidevtools/json-schema-ref-parser": 9.0.9
-    "@sinclair/typebox": 0.29.0
+    "@sinclair/typebox": 0.30.2
     "@tsconfig/node18": 2.0.0
     "@types/minimist": 1.2.2
     "@types/node": 18.16.8


### PR DESCRIPTION
Merges upstream's main into local main
- generate a Union of Literal types for JSON schema 'enum' schemas instead of previously generating typescript enums (mainly authored by Patrick Fowler)
- bump typebox to 0.30.3